### PR TITLE
Fix Vercel python builder name

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "functions": {"api/*.py": {"runtime": "vercel-python@4.7.2"}}
+  "functions": {"api/*.py": {"runtime": "@vercel/python@4.7.2"}}
 }


### PR DESCRIPTION
## Summary
- use `@vercel/python` runtime in `vercel.json`

## Testing
- `python -m py_compile app.py api/run_simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_684ce0b22fec8321872a3bdb5c52b948