### PR TITLE
Fix API fetch URL

### DIFF
--- a/main.js
+++ b/main.js
@@ -287,7 +287,9 @@ async function updateVisualisation(){
   const selectedForest = forestSel.value;
 
   try {
-    const response = await fetch('http://localhost:5000/api/run_simulation', { // USE FULL URL
+    // Use a relative path so the API works both locally (with `app.py`) and when
+    // deployed (e.g. to Vercel where the endpoint lives at `/api/run_simulation`).
+    const response = await fetch('/api/run_simulation', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- ensure the API endpoint is fetched relative to the current host so it works on localhost and deployments

## Testing
- `python -m py_compile app.py api/run_simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_684ce29936408321b162f068debe9ec7