### PR TITLE
Improve visualization legends and flux arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,15 @@
 <style>
 body{margin:0;overflow:hidden;font-family:Arial,Helvetica,sans-serif}
 canvas{display:block}
-#info,#legend,.controls{
+#info,#fluxes,#components,.controls{
     position:absolute;z-index:10;background:rgba(0,0,0,.55);color:#fff;
     padding:10px;border-radius:6px;font-size:13px;line-height:1.3
 }
 #info{top:10px;left:10px}
 .controls{top:10px;right:10px;width:180px}
-#legend{bottom:10px;left:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px}
-#legend .box{width:16px;height:16px;border-radius:3px}
+#fluxes{bottom:10px;right:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px;text-align:left}
+#components{bottom:90px;right:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px;text-align:left}
+#fluxes .box,#components .box{width:16px;height:16px;border-radius:3px}
 .controls label{display:block;margin-bottom:5px;font-weight:600}
 #flux_values{margin-top:4px}
 .controls select,.controls button{width:100%;margin-bottom:6px}
@@ -34,17 +35,29 @@ canvas{display:block}
   <hr style="border:0;border-top:1px solid #999;margin:6px 0">
   <div id="q_solar_display">Q<sub>solar</sub> : —</div>
   <div id="flux_info_canopy">Canopy sensible H : —</div>
+  <div><b>Flux values</b></div>
   <div id="flux_values"></div>
 </div>
 
 <!-- legend -------------------------------------------------------------------->
-<div id="legend">
+<div id="fluxes">
+  <div style="grid-column:1/3;font-weight:bold;margin-bottom:4px">Fluxes</div>
   <div class="box" style="background:#ffff00"></div><div>Solar (SW)</div>
   <div class="box" style="background:#ff00ff"></div><div>Long-wave (LW)</div>
   <div class="box" style="background:#ff8c00"></div><div>Sensible (H)</div>
   <div class="box" style="background:#00bfff"></div><div>Latent (LE)</div>
   <div class="box" style="background:#00ff00"></div><div>Conduction</div>
   <div class="box" style="background:#ffffff"></div><div>Snow-melt</div>
+</div>
+
+<div id="components">
+  <div style="grid-column:1/3;font-weight:bold;margin-bottom:4px">Components</div>
+  <div class="box" style="background:#8b4513"></div><div>Trunk</div>
+  <div class="box" style="background:#228b22"></div><div>Canopy</div>
+  <div class="box" style="background:#ffffff"></div><div>Snow</div>
+  <div class="box" style="background:#99ccff"></div><div>Wind</div>
+  <div class="box" style="background:#ffffaa"></div><div>Sun</div>
+  <div class="box" style="background:#8b7765"></div><div>Soil</div>
 </div>
 
 <!-- user controls ------------------------------------------------------------->


### PR DESCRIPTION
## Summary
- relocate flux legend to right side and add components legend
- list flux values explicitly in info panel
- move sun farther away and alter wind arrows
- prevent close zoom when no canopy present
- draw arrows for all flux categories

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ceb38398c8321900c4070e12e6a3e