### PR TITLE
Improve flux display and fix legend position

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ canvas{display:block}
 #info{top:10px;left:10px}
 .controls{top:10px;right:10px;width:180px}
 #fluxes{bottom:10px;right:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px;text-align:left}
-#components{bottom:90px;right:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px;text-align:left}
+#components{bottom:160px;right:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px;text-align:left}
 #fluxes .box,#components .box{width:16px;height:16px;border-radius:3px}
 .controls label{display:block;margin-bottom:5px;font-weight:600}
 #flux_values{margin-top:4px}
@@ -33,8 +33,6 @@ canvas{display:block}
   <div id="t_snow">Snow   : —</div>
   <div id="t_soil">Soil   : —</div>
   <hr style="border:0;border-top:1px solid #999;margin:6px 0">
-  <div id="q_solar_display">Q<sub>solar</sub> : —</div>
-  <div id="flux_info_canopy">Canopy sensible H : —</div>
   <div><b>Flux values</b></div>
   <div id="flux_values"></div>
 </div>


### PR DESCRIPTION
## Summary
- integrate `Qsolar` and canopy sensible heat into common flux list
- avoid per-sample recolouring of components
- move the components legend higher so it doesn't overlap with flux values

## Testing
- `python -m py_compile app.py api/run_simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_684cedf0accc8321b76cc94559ebbf71