### PR TITLE
Adjust components legend position

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ canvas{display:block}
 #info{top:10px;left:10px}
 .controls{top:10px;right:10px;width:180px}
 #fluxes{bottom:10px;right:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px;text-align:left}
-#components{bottom:160px;right:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px;text-align:left}
+#components{bottom:220px;right:10px;display:grid;grid-template-columns:auto 1fr;grid-gap:4px 8px;text-align:left}
 #fluxes .box,#components .box{width:16px;height:16px;border-radius:3px}
 .controls label{display:block;margin-bottom:5px;font-weight:600}
 #flux_values{margin-top:4px}


### PR DESCRIPTION
## Summary
- move components legend box up to avoid overlap with the flux legend

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cefd57a7083218e281f9fd8861b79